### PR TITLE
unlock composer installation for Contao 3 & 4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "keywords": ["contao", "blog", "news4ward", "newsletter"],
   "type": "contao-module",
   "homepage": "https://github.com/psi-4ward/news4ward_newsletter",
-  "license": "LGPL-3.0+",
+  "license": "LGPL-3.0-or-later",
   "authors": [
     {
       "name": "Christoph Wiechert",
@@ -22,11 +22,9 @@
   },
   "require": {
     "php": ">=5.3",
-    "contao/core": ">=3.1,<3.3",
+    "contao/core-bundle": "^3.2.1 || ^4.4",
+    "contao-community-alliance/composer-plugin": "^2.4 || ^3.0",
     "psi/news4ward": "~2"
-  },
-  "conflict": {
-    "contao/core": "3.0.*"
   },
   "extra": {
     "contao": {


### PR DESCRIPTION
This PR provides changes to the composer.json, so that this extension can be installed in Contao 3 and 4.
These changes are not tested.